### PR TITLE
Start on support for aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ dependencies = [
 name = "platform"
 version = "0.1.0"
 dependencies = [
- "syscall 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sc 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -437,11 +437,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "syscall"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "tempdir"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -596,7 +591,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum strsim 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4f380125926a99e52bc279241539c018323fab05ad6368b56f93d9369ff550"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
-"checksum syscall 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dae2c4de039bf338dd96f46621f20222c4101045dac5403b46f472608cb5b556"
 "checksum tempdir 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "f73eebdb68c14bcb24aef74ea96079830e7fa7b31a6106e42ea7ee887c1e134e"
 "checksum term 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "fa63644f74ce96fbeb9b794f66aff2a52d601cbd5e80f4b97123e3899f4570f1"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"

--- a/crt0/src/lib.rs
+++ b/crt0/src/lib.rs
@@ -12,12 +12,21 @@ use platform::types::*;
 #[no_mangle]
 #[naked]
 pub unsafe extern "C" fn _start() {
+    #[cfg(target_arch = "x86_64")]
     asm!("mov rdi, rsp
         call _start_rust"
         :
         :
         :
         : "intel", "volatile"
+    );
+    #[cfg(target_arch = "aarch64")]
+    asm!("mov x0, sp
+        bl _start_rust"
+        :
+        :
+        :
+        : "volatile"
     );
 }
 

--- a/platform/Cargo.toml
+++ b/platform/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Jeremy Soller <jackpot51@gmail.com>"]
 
 [dependencies]
-syscall = "0.2"
+sc = "0.2"

--- a/platform/src/lib.rs
+++ b/platform/src/lib.rs
@@ -4,7 +4,7 @@
 #![allow(non_camel_case_types)]
 
 #[macro_use]
-extern crate syscall;
+extern crate sc;
 
 pub use sys::*;
 

--- a/platform/src/linux/mod.rs
+++ b/platform/src/linux/mod.rs
@@ -1,5 +1,7 @@
 use types::*;
 
+const AT_FDCWD: c_int = -100;
+
 pub fn close(fildes: c_int) -> c_int {
     unsafe {
         syscall!(CLOSE, fildes) as c_int
@@ -13,11 +15,20 @@ pub fn exit(status: c_int) -> ! {
     loop {}
 }
 
+#[cfg(target_arch = "x86_64")]
 pub fn open(path: *const c_char, oflag: c_int, mode: mode_t) -> c_int {
     unsafe {
         syscall!(OPEN, path, oflag, mode) as c_int
     }
 }
+
+#[cfg(target_arch = "aarch64")]
+pub fn open(path: *const c_char, oflag: c_int, mode: mode_t) -> c_int {
+    unsafe {
+        syscall!(OPENAT, AT_FDCWD, path, oflag, mode) as c_int
+    }
+}
+
 
 pub fn write(fildes: c_int, buf: &[u8]) -> ssize_t {
     unsafe {


### PR DESCRIPTION
 - Start aarch64 support
   - crt0 - add support to _start
   - platform - aarch64 does not have the open syscall. Instead most
     libc implementations use openat() with AT_FDCWD
 - Use sc instead of syscall. sc is the maintained fork of syscall.

I'd like to get this working on my rpi3. I still need to add support to
the `va_list` crate for `aarch64`. Tests pass with all `stdio` stuff
commented out.