### PR TITLE
Implement several more string functions and add errno

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -454,6 +454,7 @@ version = "0.1.0"
 dependencies = [
  "cbindgen 0.5.0",
  "platform 0.1.0",
+ "stdlib 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,14 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "errno"
+version = "0.1.0"
+dependencies = [
+ "cbindgen 0.5.0",
+ "platform 0.1.0",
+]
+
+[[package]]
 name = "fcntl"
 version = "0.1.0"
 dependencies = [
@@ -244,6 +252,7 @@ version = "0.1.0"
 dependencies = [
  "compiler_builtins 0.1.0 (git+https://github.com/rust-lang-nursery/compiler-builtins.git)",
  "ctype 0.1.0",
+ "errno 0.1.0",
  "fcntl 0.1.0",
  "grp 0.1.0",
  "mman 0.1.0",
@@ -453,6 +462,7 @@ name = "string"
 version = "0.1.0"
 dependencies = [
  "cbindgen 0.5.0",
+ "errno 0.1.0",
  "platform 0.1.0",
  "stdlib 0.1.0",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = ["src/crt0"]
 compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins.git", default-features = false, features = ["mem"] }
 platform = { path = "src/platform" }
 ctype = { path = "src/ctype" }
+errno = { path = "src/errno" }
 fcntl = { path = "src/fcntl" }
 grp = { path = "src/grp" }
 semaphore = { path = "src/semaphore" }

--- a/src/errno/Cargo.toml
+++ b/src/errno/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
-name = "string"
+name = "errno"
 version = "0.1.0"
-authors = ["Jeremy Soller <jackpot51@gmail.com>"]
+authors = ["Alex Lyon <arcterus@mail.com>"]
 build = "build.rs"
 
 [build-dependencies]
@@ -9,5 +9,3 @@ cbindgen = { path = "../../cbindgen" }
 
 [dependencies]
 platform = { path = "../platform" }
-stdlib = { path = "../stdlib" }
-errno = { path = "../errno" }

--- a/src/errno/build.rs
+++ b/src/errno/build.rs
@@ -1,0 +1,11 @@
+extern crate cbindgen;
+
+use std::{env, fs};
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    fs::create_dir_all("../../target/include").expect("failed to create include directory");
+    cbindgen::generate(crate_dir)
+        .expect("failed to generate bindings")
+        .write_to_file("../../target/include/errno.h");
+}

--- a/src/errno/cbindgen.toml
+++ b/src/errno/cbindgen.toml
@@ -1,0 +1,6 @@
+sys_includes = []
+include_guard = "_ERRNO_H"
+language = "C"
+
+[enum]
+prefix_with_name = true

--- a/src/errno/src/lib.rs
+++ b/src/errno/src/lib.rs
@@ -162,5 +162,5 @@ pub enum Errno {
     // Operation would block (may be the same value as [EAGAIN])
     EWOULDBLOCK,
     // Cross-device link
-    EXDEV
+    EXDEV,
 }

--- a/src/errno/src/lib.rs
+++ b/src/errno/src/lib.rs
@@ -1,0 +1,166 @@
+//! errno implementation for Redox, following http://pubs.opengroup.org/onlinepubs/7908799/xsh/errno.h.html
+
+#![no_std]
+
+extern crate platform;
+
+pub enum Errno {
+    // Argument list too long
+    E2BIG = 1,
+    // Permission denied
+    EACCES,
+    // Address in use
+    EADDRINUSE,
+    // Address not available
+    EADDRNOTAVAIL,
+    // Address family not supported
+    EAFNOSUPPORT,
+    // Resource unavailable, try again (may be the same value as [EWOULDBLOCK])
+    EAGAIN,
+    // Connection already in progress
+    EALREADY,
+    // Bad file descriptor
+    EBADF,
+    // Bad message
+    EBADMSG,
+    // Device or resource busy
+    EBUSY,
+    // Operation canceled
+    ECANCELED,
+    // No child processes
+    ECHILD,
+    // Connection aborted
+    ECONNABORTED,
+    // Connection refused
+    ECONNREFUSED,
+    // Connection reset
+    ECONNRESET,
+    // Resource deadlock would occur
+    EDEADLK,
+    // Destination address required
+    EDESTADDRREQ,
+    // Mathematics argument out of domain of function
+    EDOM,
+    // Reserved
+    EDQUOT,
+    // File exists
+    EEXIST,
+    // Bad address
+    EFAULT,
+    // File too large
+    EFBIG,
+    // Host is unreachable
+    EHOSTUNREACH,
+    // Identifier removed
+    EIDRM,
+    // Illegal byte sequence
+    EILSEQ,
+    // Operation in progress
+    EINPROGRESS,
+    // Interrupted function
+    EINTR,
+    // Invalid argument
+    EINVAL,
+    // I/O error
+    EIO,
+    // Socket is connected
+    EISCONN,
+    // Is a directory
+    EISDIR,
+    // Too many levels of symbolic links
+    ELOOP,
+    // Too many open files
+    EMFILE,
+    // Too many links
+    EMLINK,
+    // Message too large
+    EMSGSIZE,
+    // Reserved
+    EMULTIHOP,
+    // Filename too long
+    ENAMETOOLONG,
+    // Network is down
+    ENETDOWN,
+    // Connection aborted by network
+    ENETRESET,
+    // Network unreachable
+    ENETUNREACH,
+    // Too many files open in system
+    ENFILE,
+    // No buffer space available
+    ENOBUFS,
+    // No message is available on the STREAM head read queue
+    ENODATA,
+    // No such device
+    ENODEV,
+    // No such file or directory
+    ENOENT,
+    // Executable file format error
+    ENOEXEC,
+    // No locks available
+    ENOLCK,
+    // Reserved
+    ENOLINK,
+    // Not enough space
+    ENOMEM,
+    // No message of the desired type
+    ENOMSG,
+    // Protocol not available
+    ENOPROTOOPT,
+    // No space left on device
+    ENOSPC,
+    // No STREAM resources
+    ENOSR,
+    // Not a STREAM
+    ENOSTR,
+    // Function not supported
+    ENOSYS,
+    // The socket is not connected
+    ENOTCONN,
+    // Not a directory
+    ENOTDIR,
+    // Directory not empty
+    ENOTEMPTY,
+    // Not a socket
+    ENOTSOCK,
+    // Not supported
+    ENOTSUP,
+    // Inappropriate I/O control operation
+    ENOTTY,
+    // No such device or address
+    ENXIO,
+    // Operation not supported on socket
+    EOPNOTSUPP,
+    // Value too large to be stored in data type
+    EOVERFLOW,
+    // Operation not permitted
+    EPERM,
+    // Broken pipe
+    EPIPE,
+    // Protocol error
+    EPROTO,
+    // Protocol not supported
+    EPROTONOSUPPORT,
+    // Protocol wrong type for socket
+    EPROTOTYPE,
+    // Result too large
+    ERANGE,
+    // Read-only file system
+    EROFS,
+    // Invalid seek
+    ESPIPE,
+    // No such process
+    ESRCH,
+    // Reserved
+    ESTALE,
+    // Stream ioctl() timeout
+    ETIME,
+    // Connection timed out
+    ETIMEDOUT,
+    // Text file busy
+    ETXTBSY,
+    // Operation would block (may be the same value as [EAGAIN])
+    EWOULDBLOCK,
+    // Cross-device link
+    EXDEV
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ extern crate compiler_builtins;
 extern crate platform;
 
 extern crate ctype;
+extern crate errno;
 extern crate fcntl;
 extern crate grp;
 extern crate mman;

--- a/src/platform/src/lib.rs
+++ b/src/platform/src/lib.rs
@@ -32,18 +32,9 @@ use types::*;
 pub static mut errno: c_int = 0;
 
 pub unsafe fn c_str(s: *const c_char) -> &'static [u8] {
-    use core::slice;
+    use core::usize;
 
-    let mut size = 0;
-
-    loop {
-        if *s.offset(size) == 0 {
-            break;
-        }
-        size += 1;
-    }
-
-    slice::from_raw_parts(s as *const u8, size as usize)
+    c_str_n(s, usize::MAX)
 }
 
 pub unsafe fn c_str_n(s: *const c_char, n: usize) -> &'static [u8] {

--- a/src/string/Cargo.toml
+++ b/src/string/Cargo.toml
@@ -9,3 +9,4 @@ cbindgen = { path = "../../cbindgen" }
 
 [dependencies]
 platform = { path = "../platform" }
+stdlib = { path = "../stdlib" }

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -2,9 +2,9 @@
 
 #![no_std]
 
+extern crate errno;
 extern crate platform;
 extern crate stdlib;
-extern crate errno;
 
 use platform::types::*;
 use errno::*;
@@ -94,10 +94,10 @@ pub unsafe extern "C" fn strdup(s1: *const c_char) -> *mut c_char {
 
 #[no_mangle]
 pub unsafe extern "C" fn strndup(s1: *const c_char, size: usize) -> *mut c_char {
-    // the "+ 1" is to account for the NUL byte
-    let len = strnlen(s1, size) + 1;
+    let len = strnlen(s1, size);
 
-    let buffer = stdlib::malloc(len) as *mut c_char;
+    // the "+ 1" is to account for the NUL byte
+    let buffer = stdlib::malloc(len + 1) as *mut c_char;
     if buffer.is_null() {
         platform::errno = Errno::ENOMEM as c_int;
     } else {
@@ -105,6 +105,7 @@ pub unsafe extern "C" fn strndup(s1: *const c_char, size: usize) -> *mut c_char 
         for i in 0..len as isize {
             *buffer.offset(i) = *s1.offset(i);
         }
+        *buffer.offset(len as isize) = 0;
     }
 
     buffer

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -87,8 +87,13 @@ pub extern "C" fn strcspn(s1: *const c_char, s2: *const c_char) -> c_ulong {
 
 #[no_mangle]
 pub unsafe extern "C" fn strdup(s1: *const c_char) -> *mut c_char {
+    strndup(s1, usize::MAX)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn strndup(s1: *const c_char, size: usize) -> *mut c_char {
     // the "+ 1" is to account for the NUL byte
-    let len = strlen(s1) + 1;
+    let len = strnlen(s1, size) + 1;
 
     let buffer = stdlib::malloc(len) as *mut _;
     if buffer.is_null() {
@@ -110,7 +115,12 @@ pub extern "C" fn strerror(errnum: c_int) -> *mut c_char {
 
 #[no_mangle]
 pub unsafe extern "C" fn strlen(s: *const c_char) -> size_t {
-    platform::c_str(s).len() as size_t
+    strnlen(s, usize::MAX)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn strnlen(s: *const c_char, size: usize) -> size_t {
+    platform::c_str_n(s, size).len() as size_t
 }
 
 #[no_mangle]

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -4,8 +4,10 @@
 
 extern crate platform;
 extern crate stdlib;
+extern crate errno;
 
 use platform::types::*;
+use errno::*;
 use core::cmp;
 use core::usize;
 
@@ -95,9 +97,9 @@ pub unsafe extern "C" fn strndup(s1: *const c_char, size: usize) -> *mut c_char 
     // the "+ 1" is to account for the NUL byte
     let len = strnlen(s1, size) + 1;
 
-    let buffer = stdlib::malloc(len) as *mut _;
+    let buffer = stdlib::malloc(len) as *mut c_char;
     if buffer.is_null() {
-        // TODO: set errno
+        platform::errno = Errno::ENOMEM as c_int;
     } else {
         //memcpy(buffer, s1, len)
         for i in 0..len as isize {


### PR DESCRIPTION
Adding `errno` was needed to finish `strdup()`/`strndup()`.