### PR TITLE
fcntl: open should use a va_list

### DIFF
--- a/include/bits/fcntl.h
+++ b/include/bits/fcntl.h
@@ -1,0 +1,13 @@
+#ifndef _BITS_FCNTL_H
+#define _BITS_FCNTL_H
+
+int open(const char* filename, int flags, ...) {
+    mode_t mode = 0;
+	va_list ap;
+	va_start(ap, flags);
+    mode = va_arg(ap, mode_t);
+	va_end(ap);
+    return sys_open(filename, flags, mode);
+}
+
+#endif

--- a/src/fcntl/cbindgen.toml
+++ b/src/fcntl/cbindgen.toml
@@ -1,5 +1,6 @@
-sys_includes = ["sys/types.h"]
+sys_includes = ["stdarg.h", "sys/types.h"]
 include_guard = "_FCNTL_H"
+trailer = "#include <bits/fcntl.h>"
 language = "C"
 
 [enum]

--- a/src/fcntl/src/lib.rs
+++ b/src/fcntl/src/lib.rs
@@ -33,7 +33,7 @@ pub const F_UNLCK: c_int = 2;
 
 #[no_mangle]
 pub extern "C" fn creat(path: *const c_char, mode: mode_t) -> c_int {
-    open(path, O_WRONLY | O_CREAT | O_TRUNC, mode)
+    sys_open(path, O_WRONLY | O_CREAT | O_TRUNC, mode)
 }
 
 #[no_mangle]
@@ -42,7 +42,7 @@ pub extern "C" fn fcntl(fildes: c_int, cmd: c_int, arg: c_int) -> c_int {
 }
 
 #[no_mangle]
-pub extern "C" fn open(path: *const c_char, oflag: c_int, mode: mode_t) -> c_int {
+pub extern "C" fn sys_open(path: *const c_char, oflag: c_int, mode: mode_t) -> c_int {
     platform::open(path, oflag, mode)
 }
 

--- a/tests/dup.c
+++ b/tests/dup.c
@@ -4,7 +4,7 @@
 
 int main(int argc, char** argv) {
     creat("dup.out", 0777);
-    int fd1 = open("dup.out", 0, 0);
+    int fd1 = open("dup.out", 0);
     int fd2 = dup(fd1);
     printf("fd %d duped into fd %d\n", fd1, fd2);
     close(fd1);


### PR DESCRIPTION
The current implementation of open requires the user to pass all three
args to the function. It should use a va_list and allow a user to
provide only the filename and flags.