### PR TITLE
string: address performance concerns for strncmp()

### DIFF
--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -161,7 +161,7 @@ pub unsafe extern "C" fn strncmp(s1: *const c_char, s2: *const c_char, n: usize)
 
     for (&a, &b) in s1.iter().zip(s2.iter()) {
         let val = (a as c_int) - (b as c_int);
-        if val != 0 || a == 0 {
+        if a != b || a == 0 {
             return val;
         }
     }

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -156,25 +156,17 @@ pub unsafe extern "C" fn strncat(s1: *mut c_char, s2: *const c_char, n: usize) -
 
 #[no_mangle]
 pub unsafe extern "C" fn strncmp(s1: *const c_char, s2: *const c_char, n: usize) -> c_int {
-    let s1 = platform::c_str_n(s1, n);
-    let s2 = platform::c_str_n(s2, n);
+    let s1 = core::slice::from_raw_parts(s1 as *const c_uchar, n);
+    let s2 = core::slice::from_raw_parts(s2 as *const c_uchar, n);
 
-    let min_len = n.min(s1.len()).min(s2.len());
-    for i in 0..min_len {
-        let val = s1[i] - s2[i];
-        if val != 0 {
-            return val as c_int;
+    for (&a, &b) in s1.iter().zip(s2.iter()) {
+        let val = (a as c_int) - (b as c_int);
+        if val != 0 || a == 0 {
+            return val;
         }
     }
 
-    // we can't just check for the NUL byte in the loop as c_str_n() removes it
-    if s1.len() > s2.len() {
-        s1[min_len] as c_int
-    } else if s1.len() < s2.len() {
-        -(s2[min_len] as c_int)
-    } else {
-        0
-    }
+    0
 }
 
 #[no_mangle]

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -27,5 +27,6 @@
 /rmdir
 /setid
 /stdlib/strtol
+/string/strncmp
 /unlink
 /write

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,7 +21,8 @@ BINS=\
 	rmdir \
 	setid \
 	sleep \
-  	stdlib/strtol \
+	stdlib/strtol \
+	string/strncmp \
 	unlink \
 	write
 

--- a/tests/string/strncmp.c
+++ b/tests/string/strncmp.c
@@ -1,0 +1,15 @@
+#include <string.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+    printf("%d\n", strncmp("a", "aa", 2));
+    printf("%d\n", strncmp("a", "aä", 2));
+    printf("%d\n", strncmp("\xFF", "\xFE", 2));
+    printf("%d\n", strncmp("", "\xFF", 1));
+    printf("%d\n", strncmp("a", "c", 1));
+    printf("%d\n", strncmp("a", "a", 2));
+
+    puts("test");
+
+    return 0;
+}

--- a/tests/string/strncmp.c
+++ b/tests/string/strncmp.c
@@ -9,7 +9,5 @@ int main(int argc, char* argv[]) {
     printf("%d\n", strncmp("a", "c", 1));
     printf("%d\n", strncmp("a", "a", 2));
 
-    puts("test");
-
     return 0;
 }


### PR DESCRIPTION
Not sure why but I couldn't test this using the test suite, so I had to manually test the function.  It seems to work fine though (_e.g._ no overflows when doing `a - b`).