### PR TITLE
Add implementations of sprintf and snprintf

### DIFF
--- a/include/bits/stdio.h
+++ b/include/bits/stdio.h
@@ -2,21 +2,39 @@
 #define _BITS_STDIO_H
 
 int fprintf(FILE * stream, const char * fmt, ...) {
-	int ret;
-	va_list ap;
-	va_start(ap, fmt);
-	ret = vfprintf(stream, fmt, ap);
-	va_end(ap);
-	return ret;
+    int ret;
+    va_list ap;
+    va_start(ap, fmt);
+    ret = vfprintf(stream, fmt, ap);
+    va_end(ap);
+    return ret;
 }
 
 int printf(const char * fmt, ...) {
-	int ret;
-	va_list ap;
-	va_start(ap, fmt);
-	ret = vprintf(fmt, ap);
-	va_end(ap);
-	return ret;
+    int ret;
+    va_list ap;
+    va_start(ap, fmt);
+    ret = vprintf(fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
+int snprintf(char *s, size_t n, const char * fmt, ...) {
+    int ret;
+    va_list ap;
+    va_start(ap, fmt);
+    ret = vsnprintf(s, n, fmt, ap);
+    va_end(ap);
+    return ret;
+}
+
+int sprintf(char *s, const char * fmt, ...) {
+    int ret;
+    va_list ap;
+    va_start(ap, fmt);
+    ret = vsprintf(s, fmt, ap);
+    va_end(ap);
+    return ret;
 }
 
 #endif /* _BITS_STDIO_H */

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -32,4 +32,11 @@ typedef int clockid_t;
 
 typedef void* timer_t;
 
+#ifdef __linux__
+#define _SC_PAGE_SIZE 30
+#endif
+#ifdef __redox__
+#define _SC_PAGE_SIZE 8
+#endif
+
 #endif /* _SYS_TYPES_H */

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -26,6 +26,7 @@
 /printf
 /rmdir
 /setid
+/sprintf
 /stdlib/strtol
 /unlink
 /write

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -21,6 +21,7 @@ BINS=\
 	rmdir \
 	setid \
 	sleep \
+	sprintf \
   	stdlib/strtol \
 	unlink \
 	write

--- a/tests/sprintf.c
+++ b/tests/sprintf.c
@@ -1,0 +1,30 @@
+
+#include <stdio.h>
+
+int main(int argc, char ** argv) {
+    char buffer[72];
+    int ret = sprintf(
+        buffer,
+        "This string fits in the buffer because it is only %d bytes in length",
+        68
+    );
+
+    if (ret) {
+        printf("Failed! %d\n", ret);
+        return -1;
+    }
+
+    ret = snprintf(
+        buffer,
+        72,
+        "This string is way longer and does not fit in the buffer because it %d bytes in length",
+        87
+    );
+
+    if (!ret) {
+        return 0;
+    } else {
+        printf("Failed! %d", ret);
+        return -1;
+    }
+}


### PR DESCRIPTION
Add implementations of sprintf and snprintf so that we can get a bit
closer to compiling libc-test.

Fixes: #55 