### PR TITLE
Add implementations of memchr and memccpy

### DIFF
--- a/src/string/Cargo.toml
+++ b/src/string/Cargo.toml
@@ -11,3 +11,4 @@ cbindgen = { path = "../../cbindgen" }
 platform = { path = "../platform" }
 stdlib = { path = "../stdlib" }
 errno = { path = "../errno" }
+compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins.git", default-features = false, features = ["mem"] }

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -29,10 +29,10 @@ pub unsafe extern "C" fn memccpy(
     }
     let src = src as *mut u8;
     let dist = (to as usize) - (src as usize);
-    if memcpy(dest, src, dist) as usize > 0 {
-        return dest.offset(dist as isize + 1) as *mut c_void;
+    if memcpy(dest, src, dist).is_null() {
+        return ptr::null_mut();
     }
-    ptr::null_mut()
+    dest.offset(dist as isize + 1) as *mut c_void
 }
 
 #[no_mangle]

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -12,6 +12,7 @@ use platform::types::*;
 use errno::*;
 use core::cmp;
 use core::usize;
+use core::ptr;
 
 #[no_mangle]
 pub unsafe extern "C" fn memccpy(
@@ -21,18 +22,17 @@ pub unsafe extern "C" fn memccpy(
     n: usize,
 ) -> *mut c_void {
     use compiler_builtins::mem::memcpy;
-    use core::mem;
     let dest = dest as *mut u8;
     let to = memchr(src, c, n);
-    if to as usize == 0 {
+    if to.is_null() {
         return to;
     }
     let src = src as *mut u8;
-    let dist = ((to as usize) - (src as usize)) / mem::size_of::<u8>();
+    let dist = (to as usize) - (src as usize);
     if memcpy(dest, src, dist) as usize > 0 {
         return dest.offset(dist as isize + 1) as *mut c_void;
     }
-    0usize as *mut c_void
+    ptr::null_mut()
 }
 
 #[no_mangle]
@@ -40,15 +40,12 @@ pub unsafe extern "C" fn memchr(s: *const c_void, c: c_int, n: usize) -> *mut c_
     let s = s as *mut u8;
     let c = c as u8;
     let mut i = 0;
-    loop {
+    for i in 0..n {
         if *s.offset(i as isize) == c {
             return s.offset(i as isize) as *mut c_void;
         }
-        i += 1;
-        if i == n {
-            return 0usize as *mut c_void;
-        }
     }
+    ptr::null_mut()
 }
 
 // #[no_mangle]

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -30,7 +30,7 @@ pub unsafe extern "C" fn memccpy(
     let src = src as *mut u8;
     let dist = ((to as usize) - (src as usize)) / mem::size_of::<u8>();
     if memcpy(dest, src, dist) as usize > 0 {
-        return dest.offset(dist as isize) as *mut c_void;
+        return dest.offset(dist as isize + 1) as *mut c_void;
     }
     0usize as *mut c_void
 }

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -20,6 +20,7 @@
 /link
 /link.out
 /math
+/mem
 /setid
 /sleep
 /pipe

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -16,6 +16,7 @@ BINS=\
 	getid \
 	link \
 	math \
+	mem \
 	pipe \
 	printf \
 	rmdir \

--- a/tests/mem.c
+++ b/tests/mem.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include <string.h>
+
+int main(int argc, char ** argv) {
+	printf("# mem #\n");
+	char arr[100];
+	memset(arr, 0, 100); // Compiler builtin, should work
+	arr[50] = 1;
+	if ((size_t)memchr((void *)arr, 1, 100) - (size_t)arr != 50) {
+		printf("Incorrect memchr\n");
+		exit(1);
+	}
+	printf("Correct memchr\n");
+	char arr2[51];
+	memset(arr2, 0, 51); // Compiler builtin, should work
+	memccpy((void *)arr2, (void *)arr, 1, 100);
+	if (arr[50] != 1) {
+		printf("Incorrect memccpy\n");
+		exit(1);
+	}
+	printf("Correct memccpy\n");
+}

--- a/tests/mem.c
+++ b/tests/mem.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 int main(int argc, char ** argv) {


### PR DESCRIPTION
The implementations in the pull request aren't based on musl as per #51, as musl does some checking with alignment. I've also added some tests.