### PR TITLE
Add implementations of strspn, strcspn and strchr

### DIFF
--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -92,16 +92,13 @@ pub unsafe extern "C" fn strcat(s1: *mut c_char, s2: *const c_char) -> *mut c_ch
 pub unsafe extern "C" fn strchr(s: *const c_char, c: c_int) -> *mut c_char {
     let c = c as i8;
     let mut i = 0;
-    loop {
-        let cur = *s.offset(i);
-        if cur == c {
+    while *s.offset(i) != 0 {
+        if *s.offset(i) == c {
             return s.offset(i) as *mut c_char;
-        }
-        if cur == 0 {
-            return ptr::null_mut();
         }
         i += 1;
     }
+    ptr::null_mut()
 }
 
 #[no_mangle]

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -125,20 +125,23 @@ pub unsafe extern "C" fn strcspn(s1: *const c_char, s2: *const c_char) -> c_ulon
 
     let s1 = s1 as *const u8;
     let s2 = s2 as *const u8;
-    
+
     // The below logic is effectively ripped from the musl implementation
 
-    let mut byteset = [0u8; 32/mem::size_of::<usize>()]; 
+    let mut byteset = [0u8; 32 / mem::size_of::<usize>()];
 
     let mut i = 0;
     while *s2.offset(i) != 0 {
-        byteset[(*s2.offset(i) as usize)/(8*mem::size_of::<usize>())] |= 1 << (*s2.offset(i) as usize % (8*mem::size_of::<usize>()));
+        byteset[(*s2.offset(i) as usize) / (8 * mem::size_of::<usize>())] |=
+            1 << (*s2.offset(i) as usize % (8 * mem::size_of::<usize>()));
         i += 1;
     }
 
     i = 0; // reset
     while *s2.offset(i) != 0 {
-        if byteset[(*s2.offset(i) as usize)/(8*mem::size_of::<usize>())] & 1 << (*s2.offset(i) as usize % (8*mem::size_of::<usize>())) > 0 {
+        if byteset[(*s2.offset(i) as usize) / (8 * mem::size_of::<usize>())]
+            & 1 << (*s2.offset(i) as usize % (8 * mem::size_of::<usize>())) > 0
+        {
             break;
         }
         i += 1;
@@ -265,20 +268,23 @@ pub unsafe extern "C" fn strspn(s1: *const c_char, s2: *const c_char) -> c_ulong
 
     let s1 = s1 as *const u8;
     let s2 = s2 as *const u8;
-    
+
     // The below logic is effectively ripped from the musl implementation
 
-    let mut byteset = [0u8; 32/mem::size_of::<usize>()]; 
+    let mut byteset = [0u8; 32 / mem::size_of::<usize>()];
 
     let mut i = 0;
     while *s2.offset(i) != 0 {
-        byteset[(*s2.offset(i) as usize)/(8*mem::size_of::<usize>())] |= 1 << (*s2.offset(i) as usize % (8*mem::size_of::<usize>()));
+        byteset[(*s2.offset(i) as usize) / (8 * mem::size_of::<usize>())] |=
+            1 << (*s2.offset(i) as usize % (8 * mem::size_of::<usize>()));
         i += 1;
     }
 
     i = 0; // reset
     while *s2.offset(i) != 0 {
-        if byteset[(*s2.offset(i) as usize)/(8*mem::size_of::<usize>())] & 1 << (*s2.offset(i) as usize % (8*mem::size_of::<usize>())) < 1 {
+        if byteset[(*s2.offset(i) as usize) / (8 * mem::size_of::<usize>())]
+            & 1 << (*s2.offset(i) as usize % (8 * mem::size_of::<usize>())) < 1
+        {
             break;
         }
         i += 1;

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -39,7 +39,6 @@ pub unsafe extern "C" fn memccpy(
 pub unsafe extern "C" fn memchr(s: *const c_void, c: c_int, n: usize) -> *mut c_void {
     let s = s as *mut u8;
     let c = c as u8;
-    let mut i = 0;
     for i in 0..n {
         if *s.offset(i as isize) == c {
             return s.offset(i as isize) as *mut c_void;

--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -90,8 +90,19 @@ pub unsafe extern "C" fn strcat(s1: *mut c_char, s2: *const c_char) -> *mut c_ch
 }
 
 #[no_mangle]
-pub extern "C" fn strchr(s: *const c_char, c: c_int) -> *mut c_char {
-    unimplemented!();
+pub unsafe extern "C" fn strchr(s: *const c_char, c: c_int) -> *mut c_char {
+    let c = c as i8;
+    let mut i = 0;
+    loop {
+        let cur = *s.offset(i);
+        if cur == c {
+            return s.offset(i) as *mut c_char;
+        }
+        if cur == 0 {
+            return ptr::null_mut();
+        }
+        i += 1;
+    }
 }
 
 #[no_mangle]
@@ -110,8 +121,30 @@ pub unsafe extern "C" fn strcpy(s1: *mut c_char, s2: *const c_char) -> *mut c_ch
 }
 
 #[no_mangle]
-pub extern "C" fn strcspn(s1: *const c_char, s2: *const c_char) -> c_ulong {
-    unimplemented!();
+pub unsafe extern "C" fn strcspn(s1: *const c_char, s2: *const c_char) -> c_ulong {
+    use core::mem;
+
+    let s1 = s1 as *const u8;
+    let s2 = s2 as *const u8;
+    
+    // The below logic is effectively ripped from the musl implementation
+
+    let mut byteset = [0u8; 32/mem::size_of::<usize>()]; 
+
+    let mut i = 0;
+    while *s2.offset(i) != 0 {
+        byteset[(*s2.offset(i) as usize)/(8*mem::size_of::<usize>())] |= 1 << (*s2.offset(i) as usize % (8*mem::size_of::<usize>()));
+        i += 1;
+    }
+
+    i = 0; // reset
+    while *s2.offset(i) != 0 {
+        if byteset[(*s2.offset(i) as usize)/(8*mem::size_of::<usize>())] & 1 << (*s2.offset(i) as usize % (8*mem::size_of::<usize>())) > 0 {
+            break;
+        }
+        i += 1;
+    }
+    i as u64
 }
 
 #[no_mangle]
@@ -228,8 +261,30 @@ pub extern "C" fn strrchr(s: *const c_char, c: c_int) -> *mut c_char {
 }
 
 #[no_mangle]
-pub extern "C" fn strspn(s1: *const c_char, s2: *const c_char) -> c_ulong {
-    unimplemented!();
+pub unsafe extern "C" fn strspn(s1: *const c_char, s2: *const c_char) -> c_ulong {
+    use core::mem;
+
+    let s1 = s1 as *const u8;
+    let s2 = s2 as *const u8;
+    
+    // The below logic is effectively ripped from the musl implementation
+
+    let mut byteset = [0u8; 32/mem::size_of::<usize>()]; 
+
+    let mut i = 0;
+    while *s2.offset(i) != 0 {
+        byteset[(*s2.offset(i) as usize)/(8*mem::size_of::<usize>())] |= 1 << (*s2.offset(i) as usize % (8*mem::size_of::<usize>()));
+        i += 1;
+    }
+
+    i = 0; // reset
+    while *s2.offset(i) != 0 {
+        if byteset[(*s2.offset(i) as usize)/(8*mem::size_of::<usize>())] & 1 << (*s2.offset(i) as usize % (8*mem::size_of::<usize>())) < 1 {
+            break;
+        }
+        i += 1;
+    }
+    i as u64
 }
 
 #[no_mangle]

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -30,5 +30,8 @@
 /sprintf
 /stdlib/strtol
 /string/strncmp
+/string/strcspn
+/string/strchr
+/string/strspn
 /unlink
 /write

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,6 +25,9 @@ BINS=\
 	sprintf \
 	stdlib/strtol \
 	string/strncmp \
+	string/strcspn \
+	string/strchr \
+	string/strspn \
 	unlink \
 	write
 

--- a/tests/string/strchr.c
+++ b/tests/string/strchr.c
@@ -1,0 +1,10 @@
+#include <string.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+	printf("%s\n", strchr("hello", 'e')); // should be ello
+	printf("%s\n", strchr("world", 'l')); // should be ld
+	printf("%s\n", strchr("world", 0)); // should be ''
+
+    return 0;
+}

--- a/tests/string/strcspn.c
+++ b/tests/string/strcspn.c
@@ -1,0 +1,9 @@
+#include <string.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+	printf("%ld\n", strcspn("hello", "world")); // should be 2
+	printf("%ld\n", strcspn("banana", "world")); // should be 6
+
+    return 0;
+}

--- a/tests/string/strspn.c
+++ b/tests/string/strspn.c
@@ -1,0 +1,10 @@
+#include <string.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+	printf("%lu\n", strspn("hello", "hello")); // should be 5
+	printf("%lu\n", strspn("world", "wendy")); // should be 1
+	printf("%lu\n", strspn("banana", "apple")); // should be 0
+
+    return 0;
+}


### PR DESCRIPTION
There's also a micro fix for an unused variable in `memchr`.

`strcspn` and `strspn` are have their operation logic ripped from musl, while `strchr` is loosely based on `memchr`.

Tests have been added for all the functions implemented.