### PR TITLE
Implemented fputc, fputs, and puts

### DIFF
--- a/src/stdio/src/lib.rs
+++ b/src/stdio/src/lib.rs
@@ -105,12 +105,22 @@ pub extern "C" fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FI
 
 #[no_mangle]
 pub extern "C" fn fputc(c: c_int, stream: *mut FILE) -> c_int {
-    unimplemented!();
+    platform::FileWriter(stream as c_int).write_char(c as u8 as char).map_err(|_| return -1);
+    c
 }
 
 #[no_mangle]
-pub extern "C" fn fputs(s: *const c_char, stream: *mut FILE) -> c_int {
-    unimplemented!();
+pub unsafe extern "C" fn fputs(s: *const c_char, stream: *mut FILE) -> c_int {
+    extern "C" {
+        fn strlen(s: *const c_char) -> size_t;
+    }
+    use core::{ str, slice };
+    let len = strlen(s);
+    platform::FileWriter(stream as c_int).write_str(str::from_utf8_unchecked(slice::from_raw_parts(
+                        s as *const u8,
+                        len,
+                    ))).map_err(|_| return -1);
+    len as i32
 }
 
 #[no_mangle]
@@ -245,8 +255,9 @@ pub unsafe extern "C" fn putchar_unlocked(c: c_int) -> c_int {
 }
 
 #[no_mangle]
-pub extern "C" fn puts(s: *const c_char) -> c_int {
-    unimplemented!();
+pub unsafe extern "C" fn puts(s: *const c_char) -> c_int {
+    fputs(s, stdout);
+    putchar(b'\n' as c_int)
 }
 
 #[no_mangle]

--- a/src/stdio/src/lib.rs
+++ b/src/stdio/src/lib.rs
@@ -105,7 +105,9 @@ pub extern "C" fn fopen(filename: *const c_char, mode: *const c_char) -> *mut FI
 
 #[no_mangle]
 pub extern "C" fn fputc(c: c_int, stream: *mut FILE) -> c_int {
-    platform::FileWriter(stream as c_int).write_char(c as u8 as char).map_err(|_| return -1);
+    platform::FileWriter(stream as c_int)
+        .write_char(c as u8 as char)
+        .map_err(|_| return -1);
     c
 }
 
@@ -114,12 +116,14 @@ pub unsafe extern "C" fn fputs(s: *const c_char, stream: *mut FILE) -> c_int {
     extern "C" {
         fn strlen(s: *const c_char) -> size_t;
     }
-    use core::{ str, slice };
+    use core::{slice, str};
     let len = strlen(s);
-    platform::FileWriter(stream as c_int).write_str(str::from_utf8_unchecked(slice::from_raw_parts(
-                        s as *const u8,
-                        len,
-                    ))).map_err(|_| return -1);
+    platform::FileWriter(stream as c_int)
+        .write_str(str::from_utf8_unchecked(slice::from_raw_parts(
+            s as *const u8,
+            len,
+        )))
+        .map_err(|_| return -1);
     len as i32
 }
 


### PR DESCRIPTION
I haven't included any tests for these, as they effectively get tested every time `printf("%s", ...)` is used.

This fixes an issue noticed by @jrraymond where `printf("%s")` caused a `not yet implemented`, which isn't very helpful when you're trying to use the test suite.