### PR TITLE
Add more crates for missing headers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,15 @@ version = "0.1.0"
 dependencies = [
  "cbindgen 0.5.0",
  "platform 0.1.0",
- "resource 0.1.0",
+]
+
+[[package]]
+name = "float"
+version = "0.1.0"
+dependencies = [
+ "cbindgen 0.5.0",
+ "fenv 0.1.0",
+ "platform 0.1.0",
 ]
 
 [[package]]
@@ -264,6 +272,7 @@ dependencies = [
  "errno 0.1.0",
  "fcntl 0.1.0",
  "fenv 0.1.0",
+ "float 0.1.0",
  "grp 0.1.0",
  "mman 0.1.0",
  "platform 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
  "grp 0.1.0",
  "mman 0.1.0",
  "platform 0.1.0",
+ "resource 0.1.0",
  "semaphore 0.1.0",
  "stat 0.1.0",
  "stdio 0.1.0",
@@ -275,6 +276,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "resource"
+version = "0.1.0"
+dependencies = [
+ "cbindgen 0.5.0",
+ "platform 0.1.0",
+ "sys_time 0.1.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,6 +97,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fenv"
+version = "0.1.0"
+dependencies = [
+ "cbindgen 0.5.0",
+ "platform 0.1.0",
+ "resource 0.1.0",
+]
+
+[[package]]
 name = "fuchsia-zircon"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -254,6 +263,7 @@ dependencies = [
  "ctype 0.1.0",
  "errno 0.1.0",
  "fcntl 0.1.0",
+ "fenv 0.1.0",
  "grp 0.1.0",
  "mman 0.1.0",
  "platform 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -266,6 +266,7 @@ dependencies = [
  "sys_time 0.1.0",
  "time 0.1.0",
  "unistd 0.1.0",
+ "wait 0.1.0",
  "wctype 0.1.0",
 ]
 
@@ -621,6 +622,15 @@ dependencies = [
 name = "vec_map"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wait"
+version = "0.1.0"
+dependencies = [
+ "cbindgen 0.5.0",
+ "platform 0.1.0",
+ "resource 0.1.0",
+]
 
 [[package]]
 name = "wctype"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ ctype = { path = "src/ctype" }
 errno = { path = "src/errno" }
 fcntl = { path = "src/fcntl" }
 fenv = { path = "src/fenv" }
+float = { path = "src/float" }
 grp = { path = "src/grp" }
 semaphore = { path = "src/semaphore" }
 mman = { path = "src/mman" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,13 +12,14 @@ members = ["src/crt0"]
 
 [dependencies]
 compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-builtins.git", default-features = false, features = ["mem"] }
-platform = { path = "src/platform" }
 ctype = { path = "src/ctype" }
 errno = { path = "src/errno" }
 fcntl = { path = "src/fcntl" }
 grp = { path = "src/grp" }
 semaphore = { path = "src/semaphore" }
 mman = { path = "src/mman" }
+platform = { path = "src/platform" }
+resource = { path = "src/resource" }
 stat = { path = "src/stat" }
 stdio = { path = "src/stdio" }
 stdlib = { path = "src/stdlib" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ string = { path = "src/string" }
 sys_time = { path = "src/sys_time" }
 time = { path = "src/time" }
 unistd = { path = "src/unistd" }
+wait = { path = "src/wait" }
 wctype = { path = "src/wctype" }
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ compiler_builtins = { git = "https://github.com/rust-lang-nursery/compiler-built
 ctype = { path = "src/ctype" }
 errno = { path = "src/errno" }
 fcntl = { path = "src/fcntl" }
+fenv = { path = "src/fenv" }
 grp = { path = "src/grp" }
 semaphore = { path = "src/semaphore" }
 mman = { path = "src/mman" }

--- a/include/bits/float.h
+++ b/include/bits/float.h
@@ -1,0 +1,6 @@
+#ifndef _BITS_FLOAT_H
+#define _BITS_FLOAT_H
+
+#define FLT_ROUNDS (flt_rounds())
+
+#endif

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -8,6 +8,7 @@ typedef long dev_t;
 typedef unsigned long ino_t;
 
 typedef int gid_t;
+
 typedef int uid_t;
 
 typedef int mode_t;
@@ -17,6 +18,8 @@ typedef unsigned long nlink_t;
 typedef long off_t;
 
 typedef int pid_t;
+
+typedef unsigned id_t;
 
 typedef long ssize_t;
 

--- a/src/fenv/Cargo.toml
+++ b/src/fenv/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "fenv"
+version = "0.1.0"
+authors = ["Dan Robertson <danlrobertson89@gmail.com>"]
+
+[build-dependencies]
+cbindgen = { path = "../../cbindgen" }
+
+[dependencies]
+platform = { path = "../platform" }

--- a/src/fenv/build.rs
+++ b/src/fenv/build.rs
@@ -1,0 +1,11 @@
+extern crate cbindgen;
+
+use std::{env, fs};
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    fs::create_dir_all("../../target/include").expect("failed to create include directory");
+    cbindgen::generate(crate_dir)
+        .expect("failed to generate bindings")
+        .write_to_file("../../target/include/fenv.h");
+}

--- a/src/fenv/cbindgen.toml
+++ b/src/fenv/cbindgen.toml
@@ -1,0 +1,6 @@
+sys_includes = ["sys/types.h"]
+include_guard = "_FENV_H"
+language = "C"
+
+[enum]
+prefix_with_name = true

--- a/src/fenv/src/lib.rs
+++ b/src/fenv/src/lib.rs
@@ -1,0 +1,62 @@
+//! fenv.h implementation for Redox, following
+//! http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/fenv.h.html
+
+#![no_std]
+
+extern crate platform;
+
+use platform::types::*;
+
+pub const FE_ALL_EXCEPT: c_int = 0;
+pub const FE_TONEAREST: c_int = 0;
+
+pub type fexcept_t = u64;
+
+#[repr(C)]
+pub struct fenv_t {
+    pub cw: u64,
+}
+
+pub unsafe extern "C" fn feclearexcept(excepts: c_int) -> c_int {
+    unimplemented!();
+}
+
+pub unsafe extern "C" fn fegenenv(envp: *mut fenv_t) -> c_int {
+    unimplemented!();
+}
+
+pub unsafe extern "C" fn fegetexceptflag(flagp: *mut fexcept_t, excepts: c_int) -> c_int {
+    unimplemented!();
+}
+
+pub unsafe extern "C" fn fegetround() -> c_int {
+    FE_TONEAREST
+}
+
+pub unsafe extern "C" fn feholdexcept(envp: *mut fenv_t) -> c_int {
+    unimplemented!();
+}
+
+pub unsafe extern "C" fn feraiseexcept(except: c_int) -> c_int {
+    unimplemented!();
+}
+
+pub unsafe extern "C" fn fesetenv(envp: *const fenv_t) -> c_int {
+    unimplemented!();
+}
+
+pub unsafe extern "C" fn fesetexceptflag(flagp: *const fexcept_t, excepts: c_int) -> c_int {
+    unimplemented!();
+}
+
+pub unsafe extern "C" fn fesetround(round: c_int) -> c_int {
+    unimplemented!();
+}
+
+pub unsafe extern "C" fn fetestexcept(excepts: c_int) -> c_int {
+    unimplemented!();
+}
+
+pub unsafe extern "C" fn feupdateenv(envp: *const fenv_t) -> c_int {
+    unimplemented!();
+}

--- a/src/float/Cargo.toml
+++ b/src/float/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "float"
+version = "0.1.0"
+authors = ["Dan Robertson <danlrobertson89@gmail.com>"]
+
+[build-dependencies]
+cbindgen = { path = "../../cbindgen" }
+
+[dependencies]
+platform = { path = "../platform" }
+fenv = { path = "../fenv" }

--- a/src/float/build.rs
+++ b/src/float/build.rs
@@ -1,0 +1,11 @@
+extern crate cbindgen;
+
+use std::{env, fs};
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    fs::create_dir_all("../../target/include").expect("failed to create include directory");
+    cbindgen::generate(crate_dir)
+        .expect("failed to generate bindings")
+        .write_to_file("../../target/include/float.h");
+}

--- a/src/float/cbindgen.toml
+++ b/src/float/cbindgen.toml
@@ -1,0 +1,6 @@
+sys_includes = ["sys/types.h", "bits/float.h"]
+include_guard = "_FLOAT_H"
+language = "C"
+
+[enum]
+prefix_with_name = true

--- a/src/float/src/lib.rs
+++ b/src/float/src/lib.rs
@@ -1,0 +1,19 @@
+//! float.h implementation for Redox, following
+//! http://pubs.opengroup.org/onlinepubs/7908799/xsh/float.h.html
+
+#![no_std]
+
+extern crate fenv;
+extern crate platform;
+
+use platform::types::*;
+use fenv::{fegetround, FE_TONEAREST};
+
+pub const FLT_RADIX: c_int = 2;
+
+pub unsafe extern "C" fn flt_rounds() -> c_int {
+    match fegetround() {
+        FE_TONEAREST => 1,
+        _ => -1,
+    }
+}

--- a/src/mman/build.rs
+++ b/src/mman/build.rs
@@ -7,5 +7,5 @@ fn main() {
     fs::create_dir_all("../../target/include").expect("failed to create include directory");
     cbindgen::generate(crate_dir)
         .expect("failed to generate bindings")
-        .write_to_file("../../target/include/mman.h");
+        .write_to_file("../../target/include/sys/mman.h");
 }

--- a/src/mman/cbindgen.toml
+++ b/src/mman/cbindgen.toml
@@ -1,5 +1,5 @@
-sys_includes = []
-include_guard = "_MMAN_H"
+sys_includes = ["sys/types.h"]
+include_guard = "_SYS_MMAN_H"
 language = "C"
 
 [enum]

--- a/src/platform/src/types.rs
+++ b/src/platform/src/types.rs
@@ -50,6 +50,7 @@ pub type off_t = i64;
 pub type mode_t = u16;
 pub type time_t = i64;
 pub type pid_t = usize;
+pub type id_t = usize;
 pub type gid_t = usize;
 pub type uid_t = usize;
 pub type dev_t = usize;

--- a/src/resource/Cargo.toml
+++ b/src/resource/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "resource"
+version = "0.1.0"
+authors = ["Dan Robertson <danlrobertson89@gmail.com>"]
+
+[build-dependencies]
+cbindgen = { path = "../../cbindgen" }
+
+[dependencies]
+platform = { path = "../platform" }
+sys_time = { path = "../sys_time" }

--- a/src/resource/build.rs
+++ b/src/resource/build.rs
@@ -1,0 +1,11 @@
+extern crate cbindgen;
+
+use std::{env, fs};
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    fs::create_dir_all("../../target/include").expect("failed to create include directory");
+    cbindgen::generate(crate_dir)
+        .expect("failed to generate bindings")
+        .write_to_file("../../target/include/sys/resource.h");
+}

--- a/src/resource/cbindgen.toml
+++ b/src/resource/cbindgen.toml
@@ -1,0 +1,6 @@
+sys_includes = ["sys/types.h"]
+include_guard = "_SYS_RESOURCE_H"
+language = "C"
+
+[enum]
+prefix_with_name = true

--- a/src/resource/src/lib.rs
+++ b/src/resource/src/lib.rs
@@ -1,0 +1,49 @@
+//! sys/resource.h implementation for Redox, following
+//! http://pubs.opengroup.org/onlinepubs/7908799/xsh/sysresource.h.html
+
+#![no_std]
+
+extern crate platform;
+extern crate sys_time;
+
+use platform::types::*;
+use sys_time::timeval;
+
+type rlim_t = u64;
+
+#[repr(C)]
+pub struct rlimit {
+    pub rlim_cur: rlim_t,
+    pub rlim_max: rlim_t,
+}
+
+#[repr(C)]
+pub struct rusage {
+    pub ru_utime: timeval,
+    pub ru_stime: timeval,
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn getpriority(which: c_int, who: id_t) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn getrlimit(resource: c_int, rlp: *mut rlimit) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn getrusage(who: c_int, r_usage: *mut rusage) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn setpriority(which: c_int, who: id_t, nice: c_int) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn setrlimit(resource: c_int, rlp: *const rlimit) -> c_int {
+    unimplemented!();
+}

--- a/src/wait/Cargo.toml
+++ b/src/wait/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "wait"
+version = "0.1.0"
+authors = ["Dan Robertson <danlrobertson89@gmail.com>"]
+
+[build-dependencies]
+cbindgen = { path = "../../cbindgen" }
+
+[dependencies]
+platform = { path = "../platform" }
+resource = { path = "../resource" }

--- a/src/wait/build.rs
+++ b/src/wait/build.rs
@@ -1,0 +1,11 @@
+extern crate cbindgen;
+
+use std::{env, fs};
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    fs::create_dir_all("../../target/include").expect("failed to create include directory");
+    cbindgen::generate(crate_dir)
+        .expect("failed to generate bindings")
+        .write_to_file("../../target/include/sys/wait.h");
+}

--- a/src/wait/cbindgen.toml
+++ b/src/wait/cbindgen.toml
@@ -1,0 +1,6 @@
+sys_includes = ["sys/types.h", "sys/resource.h"]
+include_guard = "_SYS_WAIT_H"
+language = "C"
+
+[enum]
+prefix_with_name = true

--- a/src/wait/src/lib.rs
+++ b/src/wait/src/lib.rs
@@ -1,0 +1,43 @@
+//! sys/wait.h implementation for Redox, following
+//! http://pubs.opengroup.org/onlinepubs/7908799/xsh/syswait.h.html
+
+#![no_std]
+
+extern crate platform;
+extern crate resource;
+
+use platform::types::*;
+use resource::rusage;
+
+#[no_mangle]
+pub unsafe extern "C" fn wait(stat_loc: *mut c_int) -> pid_t {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn wait3(
+    stat_loc: *mut c_int,
+    options: c_int,
+    resource_usage: *mut rusage,
+) -> pid_t {
+    unimplemented!();
+}
+
+/*
+ * TODO: implement idtype_t, id_t, and siginfo_t
+ *
+ * #[no_mangle]
+ * pub unsafe extern "C" fn waitid(
+ *     idtype: idtype_t,
+ *     id: id_t,
+ *     infop: siginfo_t,
+ *     options: c_int
+ *  ) -> c_int {
+ *      unimplemented!();
+ *  }
+ */
+
+#[no_mangle]
+pub unsafe extern "C" fn waitpid(pid: pid_t, stat_loc: *mut c_int, options: c_int) -> pid_t {
+    unimplemented!();
+}


### PR DESCRIPTION
Getting a bit closer to being able to compile `libc-test`. This PR adds the following headers

 - [sys/resource.h]
 - [sys/wait.h]
 - [fenv.h]
 - [float.h]

In addition, there are some minor fixes like `mman.h` should be located at `sys/mman.h`.

[sys/resource.h]: http://pubs.opengroup.org/onlinepubs/7908799/xsh/sysresource.h.html
[sys/wait.h]: http://pubs.opengroup.org/onlinepubs/7908799/xsh/syswait.h.html
[fenv.h]: http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/fenv.h.html
[float.h]: http://pubs.opengroup.org/onlinepubs/7908799/xsh/float.h.html