### PR TITLE
Add implementation for a64l

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -507,6 +507,7 @@ name = "string"
 version = "0.1.0"
 dependencies = [
  "cbindgen 0.5.0",
+ "compiler_builtins 0.1.0 (git+https://github.com/rust-lang-nursery/compiler-builtins.git)",
  "errno 0.1.0",
  "platform 0.1.0",
  "stdlib 0.1.0",

--- a/src/stdlib/src/lib.rs
+++ b/src/stdlib/src/lib.rs
@@ -23,8 +23,29 @@ pub const EXIT_SUCCESS: c_int = 0;
 static mut ATEXIT_FUNCS: [Option<extern "C" fn()>; 32] = [None; 32];
 
 #[no_mangle]
-pub extern "C" fn a64l(s: *const c_char) -> c_long {
-    unimplemented!();
+pub unsafe extern "C" fn a64l(s: *const c_char) -> c_long {
+    if s as isize == 0 {
+        return 0;
+    }
+    let mut l: c_long = 0;
+    for x in 0..7 {
+        let c = *((s as isize + x) as *const c_char);
+        if c == 0 {
+            // string is null terminated
+            return l;
+        }
+        // ASCII to base64 conversion:
+        let mut bits: c_long = if c < 58 {
+            (c - 46) as c_long // ./0123456789
+        } else if c < 91 {
+            (c - 53) as c_long // A-Z
+        } else {
+            (c - 59) as c_long // a-z
+        };
+        bits <<= 6 * x;
+        l |= bits;
+    }
+    return l;
 }
 
 #[no_mangle]

--- a/src/stdlib/src/lib.rs
+++ b/src/stdlib/src/lib.rs
@@ -24,12 +24,13 @@ static mut ATEXIT_FUNCS: [Option<extern "C" fn()>; 32] = [None; 32];
 
 #[no_mangle]
 pub unsafe extern "C" fn a64l(s: *const c_char) -> c_long {
-    if s as isize == 0 {
+    if s.is_null() {
         return 0;
     }
     let mut l: c_long = 0;
-    for x in 0..7 {
-        let c = *((s as isize + x) as *const c_char);
+    // a64l does not support more than 6 characters at once
+    for x in 0..6 {
+        let c = *s.offset(x);
         if c == 0 {
             // string is null terminated
             return l;

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -29,6 +29,7 @@
 /setid
 /sprintf
 /stdlib/strtol
+/stdlib/a64l
 /string/strncmp
 /string/strcspn
 /string/strchr

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -24,6 +24,7 @@ BINS=\
 	sleep \
 	sprintf \
 	stdlib/strtol \
+	stdlib/a64l \
 	string/strncmp \
 	string/strcspn \
 	string/strchr \

--- a/tests/stdlib/a64l.c
+++ b/tests/stdlib/a64l.c
@@ -1,0 +1,22 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+    char * s = "azAZ9."; // test boundaries
+    long l = a64l(s);
+    if (l != 194301926) {
+        printf("Invalid result: a64l(%s) = %ld\n", s, l);
+        return 1;
+    }
+    printf("Correct a64l: %s = %ld\n", s, l);
+
+    
+    s = "azA"; // test null terminated string
+    l = a64l(s);
+    if (l != 53222) {
+        printf("Invalid result: a64l(%s) = %ld\n", s, l);
+        return 1;
+    }
+    printf("Correct a64l: %s = %ld\n", s, l);
+    return 0;
+}


### PR DESCRIPTION
Trying to get warm with the project. Interested in comments to:

- line 27: I check for NULL, according to docs NULL results in undefined behavior. Should checks like these be made or ignored?
- line 32: very C-style dereferencing of the array pointer. I did not see any reason to convert to a slice or even string, would be unsafe with deleted c-array anyways...

When the PR gets accepted I will implement l64a (and hopefully many more functions :) )