### PR TITLE
Fixed strcspn and strspn

### DIFF
--- a/src/string/src/lib.rs
+++ b/src/string/src/lib.rs
@@ -129,15 +129,15 @@ pub unsafe extern "C" fn strcspn(s1: *const c_char, s2: *const c_char) -> c_ulon
 
     let mut i = 0;
     while *s2.offset(i) != 0 {
-        byteset[(*s2.offset(i) as usize) / (8 * mem::size_of::<usize>())] |=
-            1 << (*s2.offset(i) as usize % (8 * mem::size_of::<usize>()));
+        byteset[(*s2.offset(i) as usize) / (8 * byteset.len())] |=
+            1 << (*s2.offset(i) as usize % (8 * byteset.len()));
         i += 1;
     }
 
     i = 0; // reset
     while *s2.offset(i) != 0 {
-        if byteset[(*s2.offset(i) as usize) / (8 * mem::size_of::<usize>())]
-            & 1 << (*s2.offset(i) as usize % (8 * mem::size_of::<usize>())) > 0
+        if byteset[(*s2.offset(i) as usize) / (8 * byteset.len())]
+            & 1 << (*s2.offset(i) as usize % (8 * byteset.len())) > 0
         {
             break;
         }
@@ -281,15 +281,15 @@ pub unsafe extern "C" fn strspn(s1: *const c_char, s2: *const c_char) -> c_ulong
 
     let mut i = 0;
     while *s2.offset(i) != 0 {
-        byteset[(*s2.offset(i) as usize) / (8 * mem::size_of::<usize>())] |=
-            1 << (*s2.offset(i) as usize % (8 * mem::size_of::<usize>()));
+        byteset[(*s2.offset(i) as usize) / (8 * byteset.len())] |=
+            1 << (*s2.offset(i) as usize % (8 * byteset.len()));
         i += 1;
     }
 
     i = 0; // reset
     while *s2.offset(i) != 0 {
-        if byteset[(*s2.offset(i) as usize) / (8 * mem::size_of::<usize>())]
-            & 1 << (*s2.offset(i) as usize % (8 * mem::size_of::<usize>())) < 1
+        if byteset[(*s2.offset(i) as usize) / (8 * byteset.len())]
+            & 1 << (*s2.offset(i) as usize % (8 * byteset.len())) < 1
         {
             break;
         }


### PR DESCRIPTION
I misread the macro in the musl implementation. This PR should fix all issues with overly large bitshifting in `strcspn` and `strspn`.

Issue somewhat talking about this: #67 