### PR TITLE
Include sys/time.h in sys/resource.h

### DIFF
--- a/include/stdint.h
+++ b/include/stdint.h
@@ -49,4 +49,6 @@ typedef int64_t intmax_t;
 #define UINTMAX_MAX UINT64_MAX
 typedef uint64_t uintmax_t;
 
+#define SIZE_MAX UINT64_MAX
+
 #endif /* _STDINT_H */

--- a/src/resource/cbindgen.toml
+++ b/src/resource/cbindgen.toml
@@ -1,6 +1,7 @@
-sys_includes = ["sys/types.h"]
+sys_includes = ["sys/types.h", "sys/time.h"]
 include_guard = "_SYS_RESOURCE_H"
 language = "C"
+style = "Tag"
 
 [enum]
 prefix_with_name = true


### PR DESCRIPTION
The rusage struct makes use of the timeval structure. Make sure to
include sys/time.h so that the type is known.