### PR TITLE
exec functions

### DIFF
--- a/include/bits/exec.h
+++ b/include/bits/exec.h
@@ -1,0 +1,47 @@
+#ifndef _BITS_EXEC_H
+#define _BITS_EXEC_H
+
+int execl(const char *path, const char* argv0, ...)
+{
+	int argc;
+	va_list ap;
+	va_start(ap, argv0);
+	for (argc = 1; va_arg(ap, const char*); argc++);
+	va_end(ap);
+	{
+		int i;
+		char *argv[argc+1];
+		va_start(ap, argv0);
+		argv[0] = (char *)argv0;
+		for (i = 1; i < argc; i++) {
+			argv[i] = va_arg(ap, char *);
+		}
+		argv[i] = NULL;
+		va_end(ap);
+		return execv(path, argv);
+	}
+}
+
+int execle(const char *path, const char* argv0, ...)
+{
+	int argc;
+	va_list ap;
+	va_start(ap, argv0);
+	for (argc = 1; va_arg(ap, const char *); argc++);
+	va_end(ap);
+	{
+		int i;
+		char *argv[argc+1];
+		char **envp;
+		va_start(ap, argv0);
+		argv[0] = (char *)argv0;
+		for (i = 1; i <= argc; i++) {
+			argv[i] = va_arg(ap, char *);
+		}
+		envp = va_arg(ap, char **);
+		va_end(ap);
+		return execve(path, argv, envp);
+	}
+}
+
+#endif

--- a/src/platform/Cargo.toml
+++ b/src/platform/Cargo.toml
@@ -8,3 +8,6 @@ sc = "0.2"
 
 [target.'cfg(target_os = "redox")'.dependencies]
 redox_syscall = "0.1"
+
+[dependencies]
+ralloc = { path = "../../ralloc" }

--- a/src/platform/src/lib.rs
+++ b/src/platform/src/lib.rs
@@ -2,6 +2,8 @@
 
 #![no_std]
 #![allow(non_camel_case_types)]
+#![feature(alloc)]
+#![feature(global_allocator)]
 //TODO #![feature(thread_local)]
 
 #[cfg(all(not(feature = "no_std"), target_os = "linux"))]
@@ -22,12 +24,17 @@ mod sys;
 #[path = "redox/mod.rs"]
 mod sys;
 
+extern crate alloc;
+extern crate ralloc;
+
 pub mod types;
 
 use core::fmt;
 
 use types::*;
 
+#[global_allocator]
+static ALLOCATOR: ralloc::Allocator = ralloc::Allocator;
 //TODO #[thread_local]
 #[allow(non_upper_case_globals)]
 #[no_mangle]
@@ -52,6 +59,10 @@ pub unsafe fn c_str_n(s: *const c_char, n: usize) -> &'static [u8] {
     }
 
     slice::from_raw_parts(s as *const u8, size as usize)
+}
+
+pub unsafe fn cstr_from_bytes_with_nul_unchecked(bytes: &[u8]) -> *const c_char {
+    &*(bytes as *const [u8] as *const c_char)
 }
 
 pub struct FileWriter(pub c_int);

--- a/src/platform/src/lib.rs
+++ b/src/platform/src/lib.rs
@@ -62,7 +62,7 @@ pub unsafe fn c_str_n(s: *const c_char, n: usize) -> &'static [u8] {
 }
 
 pub unsafe fn cstr_from_bytes_with_nul_unchecked(bytes: &[u8]) -> *const c_char {
-    &*(bytes as *const [u8] as *const c_char)
+    bytes.as_ptr() as *const c_char)
 }
 
 pub struct FileWriter(pub c_int);

--- a/src/platform/src/lib.rs
+++ b/src/platform/src/lib.rs
@@ -62,7 +62,7 @@ pub unsafe fn c_str_n(s: *const c_char, n: usize) -> &'static [u8] {
 }
 
 pub unsafe fn cstr_from_bytes_with_nul_unchecked(bytes: &[u8]) -> *const c_char {
-    bytes.as_ptr() as *const c_char)
+    bytes.as_ptr() as *const c_char
 }
 
 pub struct FileWriter(pub c_int);

--- a/src/platform/src/linux/mod.rs
+++ b/src/platform/src/linux/mod.rs
@@ -48,6 +48,10 @@ pub fn dup2(fildes: c_int, fildes2: c_int) -> c_int {
     e(unsafe { syscall!(DUP3, fildes, fildes2, 0) }) as c_int
 }
 
+pub fn execve(path: *const c_char, argv: *const *mut c_char, envp: *const *mut c_char) -> c_int {
+    e(unsafe { syscall!(EXECVE, path, argv, envp) }) as c_int
+}
+
 pub fn exit(status: c_int) -> ! {
     unsafe {
         syscall!(EXIT, status);

--- a/src/stdlib/src/lib.rs
+++ b/src/stdlib/src/lib.rs
@@ -2,7 +2,6 @@
 
 #![no_std]
 #![feature(core_intrinsics)]
-#![feature(global_allocator)]
 
 extern crate ctype;
 extern crate errno;
@@ -15,9 +14,6 @@ use rand::{Rng, SeedableRng, XorShiftRng};
 
 use errno::*;
 use platform::types::*;
-
-#[global_allocator]
-static ALLOCATOR: ralloc::Allocator = ralloc::Allocator;
 
 pub const EXIT_FAILURE: c_int = 1;
 pub const EXIT_SUCCESS: c_int = 0;

--- a/src/unistd/cbindgen.toml
+++ b/src/unistd/cbindgen.toml
@@ -1,5 +1,6 @@
-sys_includes = ["stddef.h", "stdint.h", "sys/types.h"]
+sys_includes = ["stddef.h", "stdint.h", "sys/types.h", "stdarg.h", "bits/exec.h"]
 include_guard = "_UNISTD_H"
+trailer = "#include <bits/fcntl.h>"
 language = "C"
 
 [enum]

--- a/src/unistd/src/getopt.rs
+++ b/src/unistd/src/getopt.rs
@@ -1,7 +1,6 @@
 //! getopt implementation for Redox, following http://pubs.opengroup.org/onlinepubs/009695399/functions/getopt.html
 
 use super::platform::types::*;
-use super::platform;
 use super::stdio;
 use super::string;
 use core::ptr;

--- a/src/unistd/src/lib.rs
+++ b/src/unistd/src/lib.rs
@@ -8,6 +8,7 @@ extern crate string;
 
 pub use platform::types::*;
 pub use getopt::*;
+
 use core::ptr;
 
 mod getopt;
@@ -29,6 +30,9 @@ pub const F_TEST: c_int = 3;
 pub const STDIN_FILENO: c_int = 0;
 pub const STDOUT_FILENO: c_int = 1;
 pub const STDERR_FILENO: c_int = 2;
+
+#[no_mangle]
+pub static mut environ: *const *mut c_char = 0 as *const *mut c_char;
 
 #[no_mangle]
 pub extern "C" fn _exit(status: c_int) {
@@ -96,23 +100,27 @@ pub extern "C" fn encrypt(block: [c_char; 64], edflag: c_int) {
 }
 
 // #[no_mangle]
-// pub extern "C" fn execl(path: *const c_char, arg0: *const c_char /* TODO: , mut args: ... */) -> c_int {
+// pub extern "C" fn execl(path: *const c_char, args: *const *mut c_char) -> c_int {
 //     unimplemented!();
 // }
-//
+
 // #[no_mangle]
-// pub extern "C" fn execle(path: *const c_char, arg0: *const c_char /* TODO: , mut args: ... */) -> c_int {
+// pub extern "C" fn execle(
+//   path: *const c_char,
+//   args: *const *mut c_char,
+//   envp: *const *mut c_char,
+// ) -> c_int {
 //     unimplemented!();
 // }
-//
+
 // #[no_mangle]
-// pub extern "C" fn execlp(file: *const c_char, arg0: *const c_char /* TODO: , mut args: ... */) -> c_int {
+// pub extern "C" fn execlp(file: *const c_char, args: *const *mut c_char) -> c_int {
 //     unimplemented!();
 // }
 
 #[no_mangle]
 pub extern "C" fn execv(path: *const c_char, argv: *const *mut c_char) -> c_int {
-    unimplemented!();
+    unsafe { execve(path, argv, environ) }
 }
 
 #[no_mangle]
@@ -121,7 +129,7 @@ pub extern "C" fn execve(
     argv: *const *mut c_char,
     envp: *const *mut c_char,
 ) -> c_int {
-    unimplemented!();
+    platform::execve(path, argv, envp)
 }
 
 #[no_mangle]
@@ -347,7 +355,7 @@ pub extern "C" fn sbrk(incr: intptr_t) -> *mut c_void {
 
 #[no_mangle]
 pub extern "C" fn setgid(gid: gid_t) -> c_int {
-    unimplemented!();
+    platform::setregid(gid, gid)
 }
 
 #[no_mangle]
@@ -377,7 +385,7 @@ pub extern "C" fn setsid() -> pid_t {
 
 #[no_mangle]
 pub extern "C" fn setuid(uid: uid_t) -> c_int {
-    unimplemented!();
+    platform::setreuid(uid, uid)
 }
 
 #[no_mangle]

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -10,6 +10,7 @@
 /ctype
 /dup
 /error
+/exec
 /fchdir
 /fcntl
 /fsync

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -8,6 +8,7 @@ EXPECT_BINS=\
 	ctype \
 	dup \
 	error \
+	exec \
 	fchdir \
 	fcntl \
 	fsync \

--- a/tests/exec.c
+++ b/tests/exec.c
@@ -1,0 +1,8 @@
+#include <unistd.h>
+
+int main(int argc, char** argv) {
+    char *const args[1] = {"arg"};
+    execv("write", args);
+    perror("execv");
+    return 0;
+}


### PR DESCRIPTION
This isn't really ready for merge yet but I want to open this up for discussion. In issue #64, it was mentioned that we don't want C functions in our header files, but we need some intermediary C to interact with va_lists and char**s. I tried to implement execvp without header C, as you will see commented out, but couldn't get it working. I'm open to suggestions.