### PR TITLE
Add some of the basics for netinet/in.h and sys/socket.h

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,6 +140,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "in_h"
+version = "0.1.0"
+dependencies = [
+ "cbindgen 0.5.2",
+ "platform 0.1.0",
+]
+
+[[package]]
 name = "itoa"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +188,13 @@ version = "0.1.0"
 dependencies = [
  "cbindgen 0.5.2",
  "platform 0.1.0",
+]
+
+[[package]]
+name = "netinet"
+version = "0.1.0"
+dependencies = [
+ "in_h 0.1.0",
 ]
 
 [[package]]
@@ -259,6 +274,7 @@ dependencies = [
  "float 0.1.0",
  "grp 0.1.0",
  "mman 0.1.0",
+ "netinet 0.1.0",
  "platform 0.1.0",
  "resource 0.1.0",
  "semaphore 0.1.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -263,6 +263,7 @@ dependencies = [
  "resource 0.1.0",
  "semaphore 0.1.0",
  "signal 0.1.0",
+ "socket 0.1.0",
  "stat 0.1.0",
  "stdio 0.1.0",
  "stdlib 0.1.0",
@@ -345,6 +346,14 @@ dependencies = [
 
 [[package]]
 name = "signal"
+version = "0.1.0"
+dependencies = [
+ "cbindgen 0.5.2",
+ "platform 0.1.0",
+]
+
+[[package]]
+name = "socket"
 version = "0.1.0"
 dependencies = [
  "cbindgen 0.5.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ platform = { path = "src/platform" }
 resource = { path = "src/resource" }
 semaphore = { path = "src/semaphore" }
 signal = { path = "src/signal" }
+socket = { path = "src/socket" }
 stat = { path = "src/stat" }
 stdio = { path = "src/stdio" }
 stdlib = { path = "src/stdlib" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ fenv = { path = "src/fenv" }
 float = { path = "src/float" }
 grp = { path = "src/grp" }
 mman = { path = "src/mman" }
+netinet = { path = "src/netinet" }
 platform = { path = "src/platform" }
 resource = { path = "src/resource" }
 semaphore = { path = "src/semaphore" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ extern crate grp;
 extern crate mman;
 extern crate resource;
 extern crate semaphore;
+extern crate socket;
 extern crate stat;
 extern crate stdio;
 extern crate stdlib;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,7 @@ extern crate fenv;
 extern crate float;
 extern crate grp;
 extern crate mman;
+extern crate netinet;
 extern crate resource;
 extern crate semaphore;
 extern crate socket;

--- a/src/netinet/Cargo.toml
+++ b/src/netinet/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "netinet"
+version = "0.1.0"
+authors = ["Dan Robertson <danlrobertson89@gmail.com>"]
+
+[dependencies]
+in_h = { path = "in" }

--- a/src/netinet/in/Cargo.toml
+++ b/src/netinet/in/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "in_h"
+version = "0.1.0"
+authors = ["Dan Robertson <danlrobertson89@gmail.com>"]
+build = "build.rs"
+
+[build-dependencies]
+cbindgen = { path = "../../../cbindgen" }
+
+[dependencies]
+platform = { path = "../../platform" }
+socket = { path = "../../socket" }

--- a/src/netinet/in/build.rs
+++ b/src/netinet/in/build.rs
@@ -1,0 +1,12 @@
+extern crate cbindgen;
+
+use std::{env, fs};
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    fs::create_dir_all("../../../target/include").expect("failed to create include directory");
+    fs::create_dir_all("../../../target/include/netinet").expect("failed to create include directory");
+    cbindgen::generate(crate_dir)
+        .expect("failed to generate bindings")
+        .write_to_file("../../../target/include/netinet/in.h");
+}

--- a/src/netinet/in/cbindgen.toml
+++ b/src/netinet/in/cbindgen.toml
@@ -1,0 +1,10 @@
+sys_includes = ["sys/types.h", "sys/socket.h"]
+include_guard = "_NETINET_IN_H"
+style = "Tag"
+language = "C"
+
+[export]
+include = ["sockaddr_in6", "sockaddr_in", "ipv6_mreq"]
+
+[enum]
+prefix_with_name = true

--- a/src/netinet/in/src/lib.rs
+++ b/src/netinet/in/src/lib.rs
@@ -1,0 +1,58 @@
+#![no_std]
+
+#![allow(non_camel_case_types)]
+
+extern crate platform;
+extern crate socket;
+
+use platform::types::*;
+use socket::sa_family_t;
+
+pub type in_addr_t = u32;
+pub type in_port_t = u16;
+
+#[repr(C)]
+#[derive(Debug)]
+pub struct in_addr {
+    pub s_addr: in_addr_t
+}
+
+#[repr(C)]
+pub struct in6_addr {
+    pub s6_addr: [u8; 16]
+}
+
+#[repr(C)]
+pub struct sockaddr_in {
+    pub sa_family: sa_family_t,
+    pub sin_port: in_port_t,
+    pub sin_addr: in_addr
+}
+
+#[repr(C)]
+pub struct sockaddr_in6 {
+    pub sin6_family: sa_family_t,
+    pub sin6_port: in_port_t,
+    pub sin6_flowinfo: u32,
+    pub sin6_addr: in6_addr,
+    pub sin6_scope_id: u32
+}
+
+#[repr(C)]
+pub struct ipv6_mreq {
+    pub ipv6mr_multiaddr: in6_addr,
+    pub ipv6mr_interface: u32,
+}
+
+// Address String Lengths
+pub const INET_ADDRSTRLEN: c_int = 16;
+pub const INET6_ADDRSTRLEN: c_int = 46;
+
+// Protocol Numbers
+pub const IPPROTO_IP: u8 = 0x00;
+pub const IPPROTO_ICMP: u8 = 0x01;
+pub const IPPROTO_TCP: u8 = 0x06;
+pub const IPPROTO_UDP: u8 = 0x11;
+pub const IPPROTO_IPV6: u8 = 0x29;
+pub const IPPROTO_RAW: u8 = 0xff;
+pub const IPPROTO_MAX: u8 = 0xff;

--- a/src/netinet/src/lib.rs
+++ b/src/netinet/src/lib.rs
@@ -1,0 +1,3 @@
+#![no_std]
+
+extern crate in_h;

--- a/src/socket/Cargo.toml
+++ b/src/socket/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "socket"
+version = "0.1.0"
+authors = ["Dan Robertson <danlrobertson89@gmail.com>"]
+build = "build.rs"
+
+[build-dependencies]
+cbindgen = { path = "../../cbindgen" }
+
+[dependencies]
+platform = { path = "../platform" }

--- a/src/socket/build.rs
+++ b/src/socket/build.rs
@@ -1,0 +1,11 @@
+extern crate cbindgen;
+
+use std::{env, fs};
+
+fn main() {
+    let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set");
+    fs::create_dir_all("../../target/include").expect("failed to create include directory");
+    cbindgen::generate(crate_dir)
+        .expect("failed to generate bindings")
+        .write_to_file("../../target/include/sys/socket.h");
+}

--- a/src/socket/cbindgen.toml
+++ b/src/socket/cbindgen.toml
@@ -1,0 +1,11 @@
+sys_includes = ["sys/types.h"]
+include_guard = "_SYS_SOCKET_H"
+style = "Tag"
+language = "C"
+
+[defines]
+"target_os=linux" = "__linux__"
+"target_os=redox" = "__redox__"
+
+[enum]
+prefix_with_name = true

--- a/src/socket/src/lib.rs
+++ b/src/socket/src/lib.rs
@@ -1,0 +1,153 @@
+//! socket implementation for Redox, following http://pubs.opengroup.org/onlinepubs/7908799/xns/syssocket.h.html
+
+#![no_std]
+#![allow(non_camel_case_types)]
+
+extern crate platform;
+
+use platform::types::*;
+
+pub type sa_family_t = u16;
+pub type socklen_t = u32;
+
+#[repr(C)]
+pub struct sockaddr {
+    pub sa_family: sa_family_t,
+    pub sa_data: [c_char; 14],
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn accept(
+    socket: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn bind(
+    socket: c_int,
+    address: *const sockaddr,
+    address_len: socklen_t,
+) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn connect(
+    socket: c_int,
+    address: *const sockaddr,
+    address_len: socklen_t,
+) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn getpeername(
+    socket: c_int,
+    address: *const sockaddr,
+    address_len: socklen_t,
+) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn getsockname(
+    socket: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn getsockopt(
+    socket: c_int,
+    level: c_int,
+    option_name: c_int,
+    option_value: *mut c_void,
+    option_len: *mut socklen_t,
+) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn listen(socket: c_int, backlog: c_int) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn recv(
+    socket: c_int,
+    buffer: *mut c_void,
+    length: size_t,
+    flags: c_int,
+) -> ssize_t {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn recvfrom(
+    socket: c_int,
+    buffer: *mut c_void,
+    length: size_t,
+    flags: c_int,
+    address: *mut sockaddr,
+    address_len: *mut socklen_t,
+) -> ssize_t {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn send(
+    socket: c_int,
+    message: *const c_void,
+    length: size_t,
+    flags: c_int,
+) -> ssize_t {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn sento(
+    socket: c_int,
+    message: *const c_void,
+    length: size_t,
+    flags: c_int,
+    dest_addr: *const sockaddr,
+    dest_len: socklen_t,
+) -> ssize_t {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn setsockopt(
+    socket: c_int,
+    level: c_int,
+    option_name: c_int,
+    option_value: *const c_void,
+    option_len: socklen_t,
+) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn shutdown(socket: c_int, how: c_int) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn socket(domain: c_int, _type: c_int, protocol: c_int) -> c_int {
+    unimplemented!();
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn socketpair(
+    domain: c_int,
+    _type: c_int,
+    protocol: c_int,
+    socket_vector: [c_int; 2],
+) -> c_int {
+    unimplemented!();
+}


### PR DESCRIPTION
Add the basic structures for sys/socket.h and netinet/in.h and stub out some of the relevant functions

I created the crate `netinet` which then contains the crate `in_h` (cannot create a crate named just `in`). Does that seem like a reasonable approach?