### PR TITLE
build openlibm when building relibc

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+use std::env;
+use std::io;
+use std::path::Path;
+use std::process::{Command, ExitStatus};
+
+fn main() {
+    make("openlibm").expect("failed to build openlibm");
+}
+
+/// Changes the current directory to the specified path, executes the `make`
+/// command, and then changes the current directory back to the original path.
+fn make<P: AsRef<Path>>(path: P) -> io::Result<ExitStatus> {
+    env::current_dir().and_then(|pwd| {
+        env::set_current_dir(path)
+            .and(Command::new("make").status())
+            .and_then(|status| env::set_current_dir(pwd).and(Ok(status)))
+    })
+}


### PR DESCRIPTION
Adds a new `build.rs` file to build the `openlibm` dependency before building `relibc`.

Closes #7 