### PR TITLE
Implement crti.o and crtn.o

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -72,6 +72,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "crti"
+version = "0.1.0"
+
+[[package]]
+name = "crtn"
+version = "0.1.0"
+
+[[package]]
 name = "ctype"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ name = "c"
 crate-type = ["staticlib"]
 
 [workspace]
-members = ["src/crt0"]
+members = ["src/crt0", "src/crti", "src/crtn"]
 
 [build-dependencies]
 cc = "1.0"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ SRC=\
 	src/*/*/* \
 	src/*/*/*/*
 
-.PHONY: all clean fmt install libc libm test
+.PHONY: all clean fmt install libc crt libm test
 
 all: libc libm
 
@@ -38,6 +38,8 @@ install: all
 	cp -rv "target/include"/* "$(DESTDIR)/include"
 	cp -v "$(BUILD)/debug/libc.a" "$(DESTDIR)/lib"
 	cp -v "$(BUILD)/debug/crt0.o" "$(DESTDIR)/lib"
+	cp -v "$(BUILD)/debug/crti.o" "$(DESTDIR)/lib"
+	cp -v "$(BUILD)/debug/crtn.o" "$(DESTDIR)/lib"
 	cp -v "$(BUILD)/openlibm/libopenlibm.a" "$(DESTDIR)/lib/libm.a"
 
 libc: $(BUILD)/debug/libc.a crt

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,9 @@ install: all
 	cp -v "$(BUILD)/debug/crt0.o" "$(DESTDIR)/lib"
 	cp -v "$(BUILD)/openlibm/libopenlibm.a" "$(DESTDIR)/lib/libm.a"
 
-libc: $(BUILD)/debug/libc.a $(BUILD)/debug/crt0.o
+libc: $(BUILD)/debug/libc.a crt
+
+crt: $(BUILD)/debug/crt0.o $(BUILD)/debug/crti.o $(BUILD)/debug/crtn.o
 
 libm: $(BUILD)/openlibm/libopenlibm.a
 
@@ -55,12 +57,28 @@ $(BUILD)/debug/crt0.o: $(SRC)
 	cargo rustc --manifest-path src/crt0/Cargo.toml $(CARGOFLAGS) -- --emit obj=$@
 	touch $@
 
+$(BUILD)/debug/crti.o: $(SRC)
+	cargo rustc --manifest-path src/crti/Cargo.toml $(CARGOFLAGS) -- --emit obj=$@
+	touch $@
+
+$(BUILD)/debug/crtn.o: $(SRC)
+	cargo rustc --manifest-path src/crtn/Cargo.toml $(CARGOFLAGS) -- --emit obj=$@
+	touch $@
+
 $(BUILD)/release/libc.a: $(SRC)
 	cargo build --release $(CARGOFLAGS)
 	touch $@
 
 $(BUILD)/release/crt0.o: $(SRC)
 	cargo rustc --release --manifest-path src/crt0/Cargo.toml $(CARGOFLAGS) -- --emit obj=$@
+	touch $@
+
+$(BUILD)/release/crti.o: $(SRC)
+	cargo rustc --release --manifest-path src/crti/Cargo.toml $(CARGOFLAGS) -- --emit obj=$@
+	touch $@
+
+$(BUILD)/release/crtn.o: $(SRC)
+	cargo rustc --release --manifest-path src/crtn/Cargo.toml $(CARGOFLAGS) -- --emit obj=$@
 	touch $@
 
 $(BUILD)/openlibm: openlibm

--- a/src/crti/Cargo.toml
+++ b/src/crti/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "crti"
+version = "0.1.0"
+authors = ["Angelo Bulfone <mbulfone@gmail.com>"]
+
+[lib]
+name = "crti"
+crate-type = ["staticlib"]
+
+[dependencies]

--- a/src/crti/src/lib.rs
+++ b/src/crti/src/lib.rs
@@ -1,0 +1,26 @@
+//! crti
+
+#![no_std]
+#![feature(global_asm)]
+#![feature(lang_items)]
+
+global_asm!(r#"
+    .section .init,"ax",@progbits
+    .global _init
+    .type _init, @function
+    _init:
+        push %rbp
+        movq %rsp, %rbp
+
+    .section .fini,"ax",@progbits
+    .global _fini
+    .type _fini, @function
+    _fini:
+    	push %rbp
+    	movq %rsp, %rbp
+"#);
+
+#[lang = "panic_fmt"]
+pub extern "C" fn rust_begin_unwind(_fmt: ::core::fmt::Arguments, _file: &str, _line: u32) -> ! {
+    loop {}
+}

--- a/src/crtn/Cargo.toml
+++ b/src/crtn/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "crtn"
+version = "0.1.0"
+authors = ["Angelo Bulfone <mbulfone@gmail.com>"]
+
+[lib]
+name = "crtn"
+crate-type = ["staticlib"]
+
+[dependencies]

--- a/src/crtn/src/lib.rs
+++ b/src/crtn/src/lib.rs
@@ -1,0 +1,20 @@
+//! crtn
+
+#![no_std]
+#![feature(global_asm)]
+#![feature(lang_items)]
+
+global_asm!(r#"
+    .section .init,"ax",@progbits
+        popq %rbp
+        ret
+
+    .section .fini,"ax",@progbits
+        popq %rbp
+        ret
+"#);
+
+#[lang = "panic_fmt"]
+pub extern "C" fn rust_begin_unwind(_fmt: ::core::fmt::Arguments, _file: &str, _line: u32) -> ! {
+    loop {}
+}


### PR DESCRIPTION
With these 2 files, compilers should be free to use relibc as _the_ standard library. They're currently fairly hacky crates with nothing but global_asm, but I was able to successfully compile a no-op c program using a custom GCC build.

Of course the lack of completeness means most programs won't compile anyways, but it's a step forward.

One thing I noticed was that my GCC was looking for crt1.o instead of crt0.o. That was easily remedied by symlinking it. I didn't not include the symlink because that could be done as a post-install step.

Currently, they're only implemented for x86_64. If you wish, I could try implementing aarch64 versions, but I'm less familiar with that architecture.

Resolves [70](https://github.com/redox-os/relibc/issues/70)