### PR TITLE
stdlib: implement strtoul() and strtol() using a macro

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -28,6 +28,7 @@ EXPECT_BINS=\
 	stdio/freopen \
 	stdlib/bsearch \
 	stdlib/strtol \
+	stdlib/strtoul \
 	stdlib/a64l \
 	stdlib/rand \
 	string/strncmp \

--- a/tests/stdlib/strtoul.c
+++ b/tests/stdlib/strtoul.c
@@ -1,0 +1,30 @@
+#include <errno.h>
+#include <stdlib.h>
+#include <stdio.h>
+
+int main(int argc, char* argv[]) {
+    printf("%ld\n", strtoul("         -42", NULL, 0));
+    printf("%ld\n", strtoul(" +555", NULL, 0));
+    printf("%ld\n", strtoul("   1234567890    ", NULL, 0));
+
+    printf("%ld\n", strtoul("         -42", NULL, 10));
+    printf("%ld\n", strtoul(" +555", NULL, 10));
+    printf("%ld\n", strtoul("   1234567890    ", NULL, 10));
+
+    printf("%lx\n", strtoul("  0x38Acfg", NULL, 0));
+    printf("%lx\n", strtoul("0Xabcdef12", NULL, 16));
+
+    printf("%lo\n", strtoul("  073189", NULL, 0));
+    printf("%lo\n", strtoul("     073189", NULL, 8));
+
+    printf("%lo\n", strtoul("  0b", NULL, 8));
+    if(errno != 0) {
+        printf("errno is not 0 (%d), something went wrong\n", errno);
+    }
+    printf("%lo\n", strtoul("  0b", NULL, 0));
+    if(errno != 0) {
+        printf("errno is not 0 (%d), something went wrong\n", errno);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
I extracted the code from the version of `strtol()` I implemented into a macro, which I then used to define both `strtoul()` and `strtol()`.  The test is currently just the test used for `strtol()`.  This should resolve #37.

Several of the changes in this commit are from running `cargo fmt` on `stdlib`.