### PR TITLE
Simplify cstr_from_bytes_with_nul_unchecked()

### DIFF
--- a/src/platform/src/lib.rs
+++ b/src/platform/src/lib.rs
@@ -55,7 +55,7 @@ pub unsafe fn c_str_n(s: *const c_char, n: usize) -> &'static [u8] {
 }
 
 pub unsafe fn cstr_from_bytes_with_nul_unchecked(bytes: &[u8]) -> *const c_char {
-    &*(bytes as *const [u8] as *const c_char)
+    bytes.as_ptr() as *const c_char
 }
 
 // NOTE: defined here rather than in string because memcpy() is useful in multiple crates


### PR DESCRIPTION
The original implementation is modified from the `Cstr` method, but the complexity there exists because it is trying to convert to the DST `Cstr`.