### PR TITLE
Fix out-of-bounds error in strsignal

### DIFF
--- a/src/header/string/mod.rs
+++ b/src/header/string/mod.rs
@@ -366,7 +366,9 @@ pub unsafe extern "C" fn strrchr(s: *const c_char, c: c_int) -> *mut c_char {
 
 #[no_mangle]
 pub unsafe extern "C" fn strsignal(sig: c_int) -> *const c_char {
-    signal::_signal_strings[sig as usize].as_ptr() as *const c_char
+    signal::_signal_strings.get(sig as usize).unwrap_or(
+        &signal::_signal_strings[0] // Unknown signal message
+    ).as_ptr() as *const c_char
 }
 
 #[no_mangle]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -61,6 +61,7 @@ EXPECT_NAMES=\
 	string/strstr \
 	string/strtok \
 	string/strtok_r \
+	string/strsignal \
 	strings \
 	sys_epoll/epoll \
 	time/asctime \

--- a/tests/expected/string/strsignal.stdout
+++ b/tests/expected/string/strsignal.stdout
@@ -1,0 +1,1 @@
+# strsignal #

--- a/tests/string/strsignal.c
+++ b/tests/string/strsignal.c
@@ -1,0 +1,28 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <signal.h>
+
+#include "test_helpers.h"
+
+int main(void) {
+    puts("# strsignal #");
+    char *x = strsignal(SIGHUP);
+    int res;
+    if (strcmp(x, "Hangup")) {
+        printf("Incorrect strsignal (1), found: .%s.\n", x);
+        exit(EXIT_FAILURE);
+    }
+    x = strsignal(0); 
+    if (strcmp(x, "Unknown signal")) {
+        printf("Incorrect strsignal (2), found: .%s.\n", x);
+        exit(EXIT_FAILURE);
+    }
+    x = strsignal(100); 
+    if (strcmp(x, "Unknown signal")) {
+        printf("Incorrect strsignal (3), found: .%s.\n", x);
+        exit(EXIT_FAILURE);
+    }
+
+
+}


### PR DESCRIPTION
This fixes an error whereby `strsignal` can cause a panic if the signal number is invalid. Instead, we return the "Unknown signal" message.