### PR TITLE
Fix strtol/ul endptr with detected base

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -172,7 +172,7 @@ macro_rules! strto_impl {
         let num_str = $s.offset(idx);
         let res = match $base {
             0 => detect_base(num_str)
-                .and_then(|($base, i)| convert_integer(num_str.offset(i), $base)),
+                .and_then(|($base, i)| { idx += i; convert_integer(num_str.offset(i), $base) }),
             8 => convert_octal(num_str),
             16 => convert_hex(num_str),
             _ => convert_integer(num_str, $base),

--- a/tests/expected/bins_dynamic/stdlib/strtol.stdout
+++ b/tests/expected/bins_dynamic/stdlib/strtol.stdout
@@ -1,13 +1,26 @@
 -42
+endptr ""
 555
+endptr ""
 1234567890
+endptr "    "
 -42
+endptr ""
 555
+endptr ""
 1234567890
+endptr "    "
 38acf
+endptr "g"
 abcdef12
+endptr ""
 cafebeef
+endptr ""
 731
+endptr "89"
 731
+endptr "89"
 0
+endptr "b"
 0
+endptr "b"

--- a/tests/expected/bins_dynamic/stdlib/strtoul.stdout
+++ b/tests/expected/bins_dynamic/stdlib/strtoul.stdout
@@ -1,12 +1,26 @@
 -42
+endptr ""
 555
+endptr ""
 1234567890
+endptr "    "
 -42
+endptr ""
 555
+endptr ""
 1234567890
+endptr "    "
 38acf
+endptr "g"
 abcdef12
+endptr ""
+21000004
+endptr ""
 731
+endptr "89"
 731
+endptr "89"
 0
+endptr "b"
 0
+endptr "b"

--- a/tests/expected/bins_static/stdlib/strtol.stdout
+++ b/tests/expected/bins_static/stdlib/strtol.stdout
@@ -1,13 +1,26 @@
 -42
+endptr ""
 555
+endptr ""
 1234567890
+endptr "    "
 -42
+endptr ""
 555
+endptr ""
 1234567890
+endptr "    "
 38acf
+endptr "g"
 abcdef12
+endptr ""
 cafebeef
+endptr ""
 731
+endptr "89"
 731
+endptr "89"
 0
+endptr "b"
 0
+endptr "b"

--- a/tests/expected/bins_static/stdlib/strtoul.stdout
+++ b/tests/expected/bins_static/stdlib/strtoul.stdout
@@ -1,12 +1,26 @@
 -42
+endptr ""
 555
+endptr ""
 1234567890
+endptr "    "
 -42
+endptr ""
 555
+endptr ""
 1234567890
+endptr "    "
 38acf
+endptr "g"
 abcdef12
+endptr ""
+21000004
+endptr ""
 731
+endptr "89"
 731
+endptr "89"
 0
+endptr "b"
 0
+endptr "b"

--- a/tests/stdlib/strtol.c
+++ b/tests/stdlib/strtol.c
@@ -5,27 +5,42 @@
 #include "test_helpers.h"
 
 int main(void) {
-    printf("%ld\n", strtol("         -42", NULL, 0));
-    printf("%ld\n", strtol(" +555", NULL, 0));
-    printf("%ld\n", strtol("   1234567890    ", NULL, 0));
+    char *endptr;
 
-    printf("%ld\n", strtol("         -42", NULL, 10));
-    printf("%ld\n", strtol(" +555", NULL, 10));
-    printf("%ld\n", strtol("   1234567890    ", NULL, 10));
+    printf("%ld\n", strtol("         -42", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%ld\n", strtol(" +555", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%ld\n", strtol("   1234567890    ", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
 
-    printf("%lx\n", strtol("  0x38Acfg", NULL, 0));
-    printf("%lx\n", strtol("0Xabcdef12", NULL, 16));
-    printf("%lx\n", strtol("cafebeef", NULL, 16));
+    printf("%ld\n", strtol("         -42", &endptr, 10));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%ld\n", strtol(" +555", &endptr, 10));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%ld\n", strtol("   1234567890    ", &endptr, 10));
+    printf("endptr \"%s\"\n", endptr);
 
-    printf("%lo\n", strtol("  073189", NULL, 0));
-    printf("%lo\n", strtol("     073189", NULL, 8));
+    printf("%lx\n", strtol("  0x38Acfg", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%lx\n", strtol("0Xabcdef12", &endptr, 16));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%lx\n", strtol("cafebeef", &endptr, 16));
+    printf("endptr \"%s\"\n", endptr);
 
-    printf("%lo\n", strtol("  0b", NULL, 8));
+    printf("%lo\n", strtol("  073189", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%lo\n", strtol("     073189", &endptr, 8));
+    printf("endptr \"%s\"\n", endptr);
+
+    printf("%lo\n", strtol("  0b", &endptr, 8));
     if(errno != 0) {
         printf("errno is not 0 (%d), something went wrong\n", errno);
     }
-    printf("%lo\n", strtol("  0b", NULL, 0));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%lo\n", strtol("  0b", &endptr, 0));
     if(errno != 0) {
         printf("errno is not 0 (%d), something went wrong\n", errno);
     }
+    printf("endptr \"%s\"\n", endptr);
 }

--- a/tests/stdlib/strtoul.c
+++ b/tests/stdlib/strtoul.c
@@ -5,26 +5,42 @@
 #include "test_helpers.h"
 
 int main(void) {
-    printf("%ld\n", strtoul("         -42", NULL, 0));
-    printf("%ld\n", strtoul(" +555", NULL, 0));
-    printf("%ld\n", strtoul("   1234567890    ", NULL, 0));
+    char *endptr;
 
-    printf("%ld\n", strtoul("         -42", NULL, 10));
-    printf("%ld\n", strtoul(" +555", NULL, 10));
-    printf("%ld\n", strtoul("   1234567890    ", NULL, 10));
+    printf("%ld\n", strtoul("         -42", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%ld\n", strtoul(" +555", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%ld\n", strtoul("   1234567890    ", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
 
-    printf("%lx\n", strtoul("  0x38Acfg", NULL, 0));
-    printf("%lx\n", strtoul("0Xabcdef12", NULL, 16));
+    printf("%ld\n", strtoul("         -42", &endptr, 10));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%ld\n", strtoul(" +555", &endptr, 10));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%ld\n", strtoul("   1234567890    ", &endptr, 10));
+    printf("endptr \"%s\"\n", endptr);
 
-    printf("%lo\n", strtoul("  073189", NULL, 0));
-    printf("%lo\n", strtoul("     073189", NULL, 8));
+    printf("%lx\n", strtoul("  0x38Acfg", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%lx\n", strtoul("0Xabcdef12", &endptr, 16));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%lx\n", strtoul("0x21000004", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
 
-    printf("%lo\n", strtoul("  0b", NULL, 8));
+    printf("%lo\n", strtoul("  073189", &endptr, 0));
+    printf("endptr \"%s\"\n", endptr);
+    printf("%lo\n", strtoul("     073189", &endptr, 8));
+    printf("endptr \"%s\"\n", endptr);
+
+    printf("%lo\n", strtoul("  0b", &endptr, 8));
     if(errno != 0) {
         printf("errno is not 0 (%d), something went wrong\n", errno);
     }
+    printf("endptr \"%s\"\n", endptr);
     printf("%lo\n", strtoul("  0b", NULL, 0));
     if(errno != 0) {
         printf("errno is not 0 (%d), something went wrong\n", errno);
     }
+    printf("endptr \"%s\"\n", endptr);
 }


### PR DESCRIPTION
The "0" or "0x" characters with base 0 were not accounted for in the returned endptr value.